### PR TITLE
fix: only return process name instead of full path in getProcessName macos 

### DIFF
--- a/lib/src/macos.dart
+++ b/lib/src/macos.dart
@@ -25,7 +25,7 @@ class FlutterSingleInstanceMacOS extends FlutterSingleInstance {
 
       var parts = output.split(" ");
 
-      return parts.last;
+      return parts.last.split('/').last;
     }
   }
 }


### PR DESCRIPTION
The method was returning full absolute path instead of just actual process name (last part of the path). So the solution is to get rid of every thing but the desired last part which is the name we want to get.

Closes #1