### PR TITLE
fix: file not found (folder does't exists)

### DIFF
--- a/lib/flutter_single_instance.dart
+++ b/lib/flutter_single_instance.dart
@@ -198,8 +198,9 @@ abstract class FlutterSingleInstance {
 
     // Try to lock the file, if it fails, another instance is running.
     try {
-      final locker =
-          await File(pidFile.path + ".lock").open(mode: FileMode.write);
+      final file = File(pidFile.path + ".lock");
+      await file.create(recursive: true);
+      final locker = await file.open(mode: FileMode.write);
       _locker = await locker.lock();
     } catch (_) {}
 


### PR DESCRIPTION
Fixed the directory creation issue for the temporary file path.

On macOS, the app was getting the error:
"No such file or directory" (errno 2)
This happened because the directory `com.xxx` (bundle identifier folder) was not being created inside the temporary path before trying to open/create the file.

### What does this PR do?
- Create the full folder structure (parent directories) before opening the file.
- This ensures the file can be safely written even if the target directory doesn't exist yet.

### Platforms affected
- Mainly macOS (tested on MacOs/Windows/Linux)